### PR TITLE
Fixups for `cargo-semver-checks`

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -31,7 +31,9 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os:
+          - ubuntu-22.04
+          #- windows-2022
         features: ["--features git", "--features sparse", "--features local-builder,sparse"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/index.rs
+++ b/src/index.rs
@@ -29,9 +29,6 @@ pub use sparse::SparseIndex;
 #[cfg(feature = "sparse")]
 pub use sparse_remote::{AsyncRemoteSparseIndex, RemoteSparseIndex};
 
-#[cfg(any(feature = "sparse", feature = "local-builder"))]
-pub use reqwest;
-
 /// Global configuration of an index, reflecting the [contents of config.json](https://doc.rust-lang.org/cargo/reference/registries.html#index-format).
 #[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct IndexConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,12 @@ pub use index::{
 };
 pub use krate::{IndexDependency, IndexKrate, IndexVersion};
 pub use krate_name::KrateName;
+
+/// Reexports of some crates for easier downstream usage without requiring adding
+/// your own dependencies
+pub mod external {
+    #[cfg(feature = "git")]
+    pub use gix;
+    #[cfg(any(feature = "sparse", feature = "local-builder"))]
+    pub use reqwest;
+}


### PR DESCRIPTION
- Add helpers to GitError
- Make gix and reqwest exported via crate::externals

While working on a PR to resolve https://github.com/obi1kenobi/cargo-semver-checks/issues/487, that crate was looking at the error for git operations to determine if they should be retried, which is....unfortunately way more complicated with gix. So this just adds helper methods on GitError to make that use case nicer.