### PR TITLE
Fixup git operations

### DIFF
--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -350,8 +350,7 @@ impl RemoteGitIndex {
                     },
                     name: "HEAD".try_into().unwrap(),
                     deref: true,
-                }))
-                .expect("oh no");
+                }))?;
             }
 
             // Sanity check that the local HEAD points to the same commit

--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -239,7 +239,7 @@ impl RemoteGitIndex {
     /// This method performs network I/O.
     #[inline]
     pub fn fetch(&mut self) -> Result<(), Error> {
-        self.fetch_with_options(gix::progress::Discard, &AtomicBool::default())
+        self.fetch_with_options(gix::progress::Discard, &gix::interrupt::IS_INTERRUPTED)
     }
 
     /// Same as [`Self::fetch`] but allows specifying a progress implementation
@@ -350,7 +350,8 @@ impl RemoteGitIndex {
                     },
                     name: "HEAD".try_into().unwrap(),
                     deref: true,
-                }))?;
+                }))
+                .expect("oh no");
             }
 
             // Sanity check that the local HEAD points to the same commit


### PR DESCRIPTION
- Fix remote logic
- Account for new lock error
- Set committer details when updating reflog

This fixes some issues when dealing with git index repos managed by cargo that the internal testing in this crate didn't discover, namely that cargo (via git2) does not set remotes, and updating reflogs requires that a committer be set by gix which isn't the case in CI environments (I guess that doesn't apply if the remote is a directory on the same filesystem?). So this PR resolves both those issues.