### PR TITLE
Write and use `FETCH_HEAD`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#7](https://github.com/EmbarkStudios/tame-index/pull/7) fixed an issue where `RemoteGitIndex::fetch` could fail in environments where the git committer was not configured.
+
+### Changed
+- [PR#7](https://github.com/EmbarkStudios/tame-index/pull/7) change how `RemoteGitIndex` looks up blobs. Previously fetching would actually update references, now however we write a `FETCH_HEAD` similarly to git/libgit2, and uses that (or other) reference to find the commit to use, rather than updating the HEAD to point to the same commit as the remote HEAD.
+
 ## [0.2.3] - 2023-07-26
 ### Fixed
 - [PR#6](https://github.com/EmbarkStudios/tame-index/pull/6) fixed two bugs with git registries.

--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -338,6 +338,8 @@ impl RemoteGitIndex {
                     config.commit_auto_rollback().map_err(Box::new)?
                 };
 
+                assert_eq!(repo.committer().unwrap().unwrap().name, "tame-index");
+
                 repo.edit_reference(edit.unwrap_or_else(|| tx::RefEdit {
                     change: tx::Change::Update {
                         log: tx::LogChange {

--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -166,7 +166,8 @@ impl RemoteGitIndex {
                 .iter()
                 .enumerate()
                 .filter_map(|(i, refname)| {
-                    let ref_id = dbg!(repo.find_reference(*refname))
+                    let ref_id = repo
+                        .find_reference(*refname)
                         .ok()?
                         .into_fully_peeled_id()
                         .ok()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,9 @@
 
 use crate::{Error, InvalidUrl, InvalidUrlError, PathBuf};
 
+#[cfg(feature = "git")]
+pub mod git;
+
 /// Returns the storage directory (in utf-8) used by Cargo, often knowns as
 /// `.cargo` or `CARGO_HOME`
 #[inline]

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -116,6 +116,14 @@ pub fn write_fetch_head(
         fetch_head
     };
 
+    // We _could_ also emit other branches/tags like git does, however it's more
+    // complicated than just our limited use case of writing remote HEAD
+    //
+    // 1. Remote branches are always emitted, however in gix those aren't part
+    // of the ref mappings if they haven't been updated since the last fetch
+    // 2. Conversely, tags are _not_ written by git unless they have been changed
+    // added, but gix _does_ always place those in the fetch mappings
+
     if fetch_head.is_empty() {
         return Err(GitError::UnableToFindRemoteHead.into());
     }
@@ -124,5 +132,5 @@ pub fn write_fetch_head(
     std::fs::write(&fetch_head_path, fetch_head)
         .map_err(|io| Error::IoPath(io, fetch_head_path))?;
 
-    Ok(oid.clone())
+    Ok(*oid)
 }

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -1,0 +1,124 @@
+//! Utilities for working with gix that might be useful for downstream users
+
+use crate::{error::GitError, Error};
+
+/// Writes the FETCH_HEAD for the specified fetch outcome to the specified git
+/// repository
+///
+/// This function is narrowly focused on on writing a `FETCH_HEAD` that contains
+/// exactly two pieces of information, the id of the commit pointed to by the
+/// remote `HEAD`, and, if it exists, the same id with the remote branch whose
+/// `HEAD` is the same. This focus gives use two things:
+///     1. `FETCH_HEAD` that can be parsed to the correct remote HEAD by
+/// [`gix`](https://github.com/Byron/gitoxide/commit/eb2b513bd939f6b59891d0a4cf5465b1c1e458b3)
+///     1. A `FETCH_HEAD` that closely (or even exactly) matches that created by
+/// cargo via git or git2 when fetching only `+HEAD:refs/remotes/origin/HEAD`
+///
+/// Calling this function for the fetch outcome of a clone will write FETCH_HEAD
+/// just as if a normal fetch had occurred, but note that AFAICT neither git nor
+/// git2 does this, ie. a fresh clone will not have a FETCH_HEAD present. I don't
+/// _think_ that has negative implications, but if it does...just don't call this
+/// function on the result of a clone :)
+///
+/// Note that the remote provided should be the same remote used for the fetch
+/// operation. The reason this is not just grabbed from the repo is because
+/// repositories may not have the configured remote, or the remote was modified
+/// (eg. replacing refspecs) before the fetch operation
+pub fn write_fetch_head(
+    repo: &gix::Repository,
+    fetch: &gix::remote::fetch::Outcome,
+    remote: &gix::Remote<'_>,
+) -> Result<gix::ObjectId, Error> {
+    use gix::{bstr::ByteSlice, protocol::handshake::Ref};
+    use std::fmt::Write;
+
+    // Find the remote head commit
+    let (head_target_branch, oid) = fetch
+        .ref_map
+        .mappings
+        .iter()
+        .find_map(|mapping| {
+            let gix::remote::fetch::Source::Ref(rref) = &mapping.remote else { return None; };
+
+            let Ref::Symbolic {
+                full_ref_name,
+                target,
+                object,
+            } = rref else { return None; };
+
+            (full_ref_name == "HEAD").then(|| (target, object))
+        })
+        .ok_or_else(|| GitError::UnableToFindRemoteHead)?;
+
+    let remote_url = {
+        let ru = remote
+            .url(gix::remote::Direction::Fetch)
+            .expect("can't fetch without a fetch url");
+        let s = ru.to_bstring();
+        let v = s.into();
+        String::from_utf8(v).expect("remote url was not utf-8 :-/")
+    };
+
+    let mut hex_id = [0u8; 40];
+    let gix::ObjectId::Sha1(sha1) = oid;
+    let commit_id = crate::utils::encode_hex(&sha1, &mut hex_id);
+
+    let mut fetch_head = String::new();
+
+    let remote_name = remote
+        .name()
+        .and_then(|n| {
+            let gix::remote::Name::Symbol(name) = n else { return None; };
+            Some(name.as_ref())
+        })
+        .unwrap_or("origin");
+
+    // We write the remote HEAD first, but _only_ if it was explicitly requested
+    if remote
+        .refspecs(gix::remote::Direction::Fetch)
+        .iter()
+        .any(|rspec| {
+            let rspec = rspec.to_ref();
+            if !rspec.remote().map_or(false, |r| r.ends_with(b"HEAD")) {
+                return false;
+            }
+
+            rspec.local().map_or(false, |l| {
+                l.to_str()
+                    .ok()
+                    .and_then(|l| {
+                        l.strip_prefix("refs/remotes/")
+                            .and_then(|l| l.strip_suffix("/HEAD"))
+                    })
+                    .map_or(false, |remote| remote == remote_name)
+            })
+        })
+    {
+        writeln!(&mut fetch_head, "{commit_id}\t\t{remote_url}").unwrap();
+    }
+
+    // Attempt to get the branch name, but if it looks suspect just skip this,
+    // it _should_ be fine, or at least, we've already written the only thing
+    // that gix can currently parse
+    if let Some(branch_name) = head_target_branch
+        .to_str()
+        .ok()
+        .and_then(|s| s.strip_prefix("refs/heads/"))
+    {
+        writeln!(
+            &mut fetch_head,
+            "{commit_id}\t\tbranch '{branch_name}' of {remote_url}"
+        )
+        .unwrap();
+    }
+
+    if fetch_head.is_empty() {
+        return Err(GitError::UnableToFindRemoteHead.into());
+    }
+
+    let fetch_head_path = crate::PathBuf::from_path_buf(repo.path().join("FETCH_HEAD"))?;
+    std::fs::write(&fetch_head_path, fetch_head)
+        .map_err(|io| Error::IoPath(io, fetch_head_path))?;
+
+    Ok(oid.clone())
+}

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -487,8 +487,6 @@ fn non_main_local_branch() {
             .detach()
         };
 
-        dbg!(&commit);
-
         use gix::refs::transaction as tx;
         repo.edit_references([
             tx::RefEdit {


### PR DESCRIPTION
This PR makes a big change to how the RemoteGitIndex performs fetches (and clones) and subsequently reads blobs, to resolve issues discovered while doing https://github.com/obi1kenobi/cargo-semver-checks/pull/506

Previously when performing a fetch, we also updated references so that HEAD pointed at the same commit as the remote HEAD. This works fine in local operation and in tests, but had a drawback, namely

```
Error: Failed to update references to their new position to match their remote locations

Caused by:
    0: The reflog could not be created or updated
    1: reflog messages need a committer which isn't set
```

can occur in CI environments. My attempts to fix this...failed (configuring a committer name + email before editing references).

Then I noticed https://github.com/frewsxcv/rust-crates-index/pull/129 which....is just way better than that previous approach since we don't need to edit references any longer just to be able to use `repo.head_commit` for reading blobs, but rather just store the remote HEAD when opening/fetching and retrieving the tree to lookup blobs from that, sidestepping the whole issue with updating references.

There is a big difference between that PR though, in that this PR also adds a function (`crate::utils::git::write_fetch_head`) to actually write a FETCH_HEAD _similarly_ to how cargo, via git or libgit2 writes FETCH_HEAD when performing a fetch on an index.

This was done for 2 reasons:

1. Performing a fetch of an index via this crate will now update the index repository the same as cargo would, which makes this play nicer with cargo and thus the wider ecosystem
2. I had already done (a slightly worse) version of writing a FETCH_HEAD for [cargo-deny](https://github.com/EmbarkStudios/cargo-deny/blob/main/src/advisories/helpers/db.rs#L451-L457), because, AFAIK, retrieving the timestamp of the FETCH_HEAD file is by far the [most/only reliable](https://stackoverflow.com/questions/2993902/how-do-i-check-the-date-and-time-of-the-latest-git-pull-that-was-executed) way to determine when a fetch was last performed on a repository. The reason this was important for cargo deny is that it fetches advisory databases, but can decide _not_ to fetch them if the user doesn't want to perform network calls, however if they _never_ fetch from the remote advisory db they run the risk of mistakenly thinking everything is fine even if they have crate dependencies that have active advisories that were added/modified since the last time they fetched. So until `gix` adds support for writing FETCH_HEAD (which I think is planned, but couldn't find it), making this function public allows cargo-deny or others to also have a (simple, definitely not git/libgit2 compliant) way to write a FETCH_HEAD with gix.