### PR TITLE
Fix issue with cargo version parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#9](https://github.com/EmbarkStudios/tame-index/pull/9) resolved [#8](https://github.com/EmbarkStudios/tame-index/issues/8) by ensuring (valid) non-official cargo build version output can also be parsed.
+
 ## [0.2.4] - 2023-07-28
 ### Fixed
 - [PR#7](https://github.com/EmbarkStudios/tame-index/pull/7) fixed an issue where `RemoteGitIndex::fetch` could fail in environments where the git committer was not configured.

--- a/src/index/location.rs
+++ b/src/index/location.rs
@@ -84,12 +84,11 @@ impl<'iu> IndexUrl<'iu> {
                 if let Some(si) = sparse_index {
                     si
                 } else {
-                    let semver = match cargo_version {
-                        Some(v) => std::borrow::Cow::Borrowed(v),
-                        None => crate::utils::cargo_version(None)?.into(),
+                    let vers = match cargo_version {
+                        Some(v) => v.trim().parse()?,
+                        None => crate::utils::cargo_version(None)?,
                     };
 
-                    let vers: semver::Version = semver.parse()?;
                     vers >= semver::Version::new(1, 70, 0)
                 }
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -220,7 +220,7 @@ use std::io;
 ///
 /// This handles the 2? cases that I am aware of
 ///
-/// 1. Official cargo prints `cargo <semver>(?:-<channel>)? (<sha1[..7]> <date>)
+/// 1. Official cargo prints `cargo <semver>(?:-<channel>)? (<sha1[..7]> <date>)`
 /// 2. Non-official builds may drop the additional metadata and just print `cargo <semver>`
 #[inline]
 fn parse_cargo_semver(s: &str) -> Result<semver::Version, Error> {


### PR DESCRIPTION
Non-official cargo builds may have differing output for `cargo -V` that the previous code wasn't accounting for, the output is now properly trimmed to remove excess whitespace before attempting to parse it into a semver.

Resolves: #8 