### PR TITLE
Use string versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- [PR#10](https://github.com/EmbarkStudios/tame-index/pull/10) unfortunately had to [relax the constraint](https://github.com/rustsec/rustsec/issues/759) that crate versions in an index are always parsable as `semver::Version`.
+
 ## [0.2.5] - 2023-08-02
 ### Fixed
 - [PR#9](https://github.com/EmbarkStudios/tame-index/pull/9) resolved [#8](https://github.com/EmbarkStudios/tame-index/issues/8) by ensuring (valid) non-official cargo build version output can also be parsed.

--- a/tests/cache.rs
+++ b/tests/cache.rs
@@ -30,14 +30,12 @@ fn parses_current_cargo_cache() {
         .expect("failed to parse cache entry")
         .unwrap();
 
-    /// The initial version of camino used by this crate, this version will _always_
-    /// exist in the index, even if it yanked in the future, and is otherwise immutable
-    const VERSION: semver::Version = semver::Version::new(1, 1, 4);
-
+    // The initial version of camino used by this crate, this version will _always_
+    // exist in the index, even if it yanked in the future, and is otherwise immutable
     let camino_version = camino
         .versions
         .iter()
-        .find(|iv| iv.version == VERSION)
+        .find(|iv| iv.version == "1.1.4")
         .expect("failed to find expected version");
 
     assert_eq!(

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -24,7 +24,7 @@ fn builds_local_registry() {
 
     struct IndexPkg {
         ik: tame_index::IndexKrate,
-        versions: Vec<semver::Version>,
+        versions: Vec<smol_str::SmolStr>,
     }
 
     for pkg in &md.packages {
@@ -43,7 +43,7 @@ fn builds_local_registry() {
             }
         });
 
-        ip.versions.push(pkg.version.clone());
+        ip.versions.push(pkg.version.to_string().into());
     }
 
     let client = local::builder::Client::build(reqwest::blocking::ClientBuilder::new()).unwrap();

--- a/tests/sparse.rs
+++ b/tests/sparse.rs
@@ -200,6 +200,6 @@ fn end_to_end() {
     spdx_krate
         .versions
         .iter()
-        .find(|iv| iv.version == semver::Version::new(0, 10, 1))
+        .find(|iv| iv.version == "0.10.1")
         .expect("failed to find expected version");
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -67,7 +67,7 @@ pub fn fake_krate(name: &str, num_versions: u8) -> IndexKrate {
             _ => unreachable!(),
         }
 
-        let iv = tame_index::IndexVersion::fake(name, version.clone());
+        let iv = tame_index::IndexVersion::fake(name, version.to_string());
         versions.push(iv);
     }
 


### PR DESCRIPTION
Incredibly unfortunate, but for full compatibility with crates.io, and possibly other indices, we need to be able to deserialize crates from the index that have invalid versions according to the the semver spec (as implemented in `semver`).

See https://github.com/rustsec/rustsec/issues/759