### PR TITLE
Make locking behavior configurable

### DIFF
--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -25,6 +25,10 @@ impl RemoteGitIndex {
     /// This function will wait to aquire the lock on the local directory for up to 10 minutes,
     /// and then return `GitError::Lock` if it is still locked by another thread or process.
     /// You can customize this behavior using [Self::with_options].
+    ///
+    /// Regardless of the timeout, this function relies on `panic = unwind` to avoid leaving stale locks
+    /// if the process is interrupted with Ctrl+C. To support `panic = abort` you also need to register
+    /// the `gix` signal handler to clean up the locks, see [`gix::interrupt::init_handler`].
     #[inline]
     pub fn new(index: GitIndex) -> Result<Self, Error> {
         Self::with_options(

--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -51,7 +51,11 @@ impl RemoteGitIndex {
 
     /// Creates a new [`Self`] that allows showing of progress of the the potential
     /// fetch if the disk location is empty, as well as allowing interruption
-    /// of the fetch operation
+    /// of the fetch operation.
+    ///
+    /// Regardless of the `lock_policy`, this function relies on `panic = unwind` to avoid leaving stale locks
+    /// if the process is interrupted with Ctrl+C. To support `panic = abort` you also need to register
+    /// a signal handler that sets `should_interrupt` to `true`.
     pub fn with_options<P>(
         mut index: GitIndex,
         progress: P,


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Makes the locking behavior configurable by API users. 

Needed for `cargo audit` to avoid inexplicable hangs when waiting on a lock: it will first attempt to lock the directory immediately, and if that fails, print a message and only after that start waiting for the lock.

### Related Issues

#12, https://github.com/rustsec/rustsec/pull/934