### PR TITLE
Allow using `rustls-native-certs` instead of `webpki-roots`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,18 @@ homepage = "https://github.com/EmbarkStudios/tame-index"
 repository = "https://github.com/EmbarkStudios/tame-index"
 
 [features]
-default = []
+default = ["reqwest?/rustls-tls-webpki-roots"]
 # Enables the built-in support for fetching and reading a git registry index
-git = ["dep:gix"]
+git = ["dep:gix", "dep:reqwest"]
 # Enables the built-in support for requesting index entries from a HTTP sparse registry index
 sparse = ["dep:reqwest", "dep:tokio", "dep:rayon", "dep:crossbeam-channel"]
 # Enables local registry support
 local = ["dep:sha2", "dep:bytes"]
 # Enables helpers for building a local registry
 local-builder = ["local", "dep:reqwest"]
+# Enables the use of OS native certificate store.
+# Should be used with `default-features = false` to also disable webpki-roots, which is activated by default.
+native-certs = ["reqwest?/rustls-tls-native-roots"]
 
 [dependencies]
 bytes = { version = "1.4", optional = true }
@@ -61,14 +64,15 @@ default-features = false
 features = [
     "max-performance-safe",
     "blocking-network-client",
-    "blocking-http-transport-reqwest-rust-tls",
+    "blocking-http-transport-reqwest",
+    "reqwest-for-configuration-only",
 ]
 
 [dependencies.reqwest]
 optional = true
 version = "0.11"
 default-features = false
-features = ["blocking", "gzip", "rustls-tls"]
+features = ["blocking", "gzip"]
 
 [dev-dependencies]
 cargo_metadata = "0.17"


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Keep `webpki-roots` enabled by default, but allow optionally using `rustls-native-certs` instead.

This is needed for `cargo audit` which sometimes runs in strange enterprise environments where all HTTPS traffic is intercepted by a MitM proxy, and it's impossible to contact the outside world without using the OS's native HTTPS certificate store.

This is the approach to configuration recommended by @Byron, here: https://github.com/Byron/gitoxide/issues/991

I have verified with `cargo tree` that the features are toggled correctly.

### Related Issues

- https://github.com/rustsec/rustsec/issues/939
- https://github.com/Byron/gitoxide/issues/991
