### PR TITLE
Bump gix version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ twox-hash = { version = "1.6", default-features = false }
 
 [dependencies.gix]
 optional = true
-version = "0.51"
+version = "0.52"
 default-features = false
 features = [
     "max-performance-safe",


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Bumps `gix` from 0.51 to 0.52. Changelog: https://github.com/Byron/gitoxide/releases/tag/gix-v0.52.0

Now that #18 is breaking API, might as well bump to the latest gix version while we're at it. There aren't any dramatic improvements to it that are relevant to `tame-index`.

### Related Issues

None