### PR TITLE
Don't force HTTP/2

### DIFF
--- a/benches/sparse.rs
+++ b/benches/sparse.rs
@@ -19,7 +19,6 @@ fn main() {
         tame_index::index::RemoteSparseIndex::new(
             tame_index::SparseIndex::new(loc).unwrap(),
             tame_index::external::reqwest::blocking::ClientBuilder::new()
-                .http2_prior_knowledge()
                 .build()
                 .unwrap(),
         )
@@ -34,7 +33,6 @@ fn main() {
         tame_index::index::AsyncRemoteSparseIndex::new(
             tame_index::SparseIndex::new(loc).unwrap(),
             tame_index::external::reqwest::ClientBuilder::new()
-                .http2_prior_knowledge()
                 .build()
                 .unwrap(),
         )

--- a/src/index/sparse.rs
+++ b/src/index/sparse.rs
@@ -97,7 +97,7 @@ impl SparseIndex {
 
         let url = self.crate_url(name);
 
-        let mut req = http::Request::get(url).version(http::Version::HTTP_2);
+        let mut req = http::Request::get(url);
 
         {
             let headers = req.headers_mut().unwrap();

--- a/tests/sparse.rs
+++ b/tests/sparse.rs
@@ -194,7 +194,6 @@ fn end_to_end() {
     let index = crates_io(&td);
 
     let client = reqwest::blocking::Client::builder()
-        .http2_prior_knowledge()
         .build()
         .unwrap();
 

--- a/tests/sparse.rs
+++ b/tests/sparse.rs
@@ -193,9 +193,7 @@ fn end_to_end() {
     let td = utils::tempdir();
     let index = crates_io(&td);
 
-    let client = reqwest::blocking::Client::builder()
-        .build()
-        .unwrap();
+    let client = reqwest::blocking::Client::builder().build().unwrap();
 
     let rsi = tame_index::index::RemoteSparseIndex::new(index, client);
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Do not force HTTP/2. Corporate transparent proxies often do not support it, but `cargo audit` needs to run in these environments.

After this change HTTP/2 will be used where available, but the download will not fail if it's not.

### Related Issues

https://github.com/rustsec/rustsec/issues/988