### PR TITLE
update `gix` to the latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,13 +59,10 @@ twox-hash = { version = "1.6", default-features = false }
 
 [dependencies.gix]
 optional = true
-version = "0.52"
+version = "0.53.1"
 default-features = false
 features = [
-    "max-performance-safe",
-    "blocking-network-client",
     "blocking-http-transport-reqwest",
-    "reqwest-for-configuration-only",
 ]
 
 [dependencies.reqwest]

--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -63,7 +63,7 @@ impl RemoteGitIndex {
         lock_policy: gix::lock::acquire::Fail,
     ) -> Result<Self, Error>
     where
-        P: gix::Progress,
+        P: gix::NestedProgress,
         P::SubProgress: 'static,
     {
         let open_or_clone_repo = || -> Result<_, GitError> {
@@ -339,7 +339,7 @@ impl RemoteGitIndex {
         should_interrupt: &AtomicBool,
     ) -> Result<(), Error>
     where
-        P: gix::Progress,
+        P: gix::NestedProgress,
         P::SubProgress: 'static,
     {
         // We're updating the reflog which requires a committer be set, which might
@@ -416,7 +416,7 @@ pub enum GitError {
     #[error(transparent)]
     ReferenceLookup(#[from] Box<gix::reference::find::existing::Error>),
     #[error(transparent)]
-    BlobLookup(#[from] Box<gix::odb::find::existing::Error<gix::odb::store::find::Error>>),
+    BlobLookup(#[from] Box<gix::odb::find::existing::Error>),
     #[error(transparent)]
     RemoteLookup(#[from] Box<gix::remote::find::existing::Error>),
     #[error(transparent)]

--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -118,7 +118,8 @@ impl RemoteGitIndex {
                     .configure_remote(|remote| {
                         Ok(remote.with_refspecs(["+HEAD:refs/remotes/origin/HEAD"], DIR)?)
                     })
-                    .fetch_only(progress, should_interrupt)?;
+                    .fetch_only(progress, should_interrupt)
+                    .map_err(|err| GitError::from(Box::new(err)))?;
 
                 (repo, Some(out))
             };
@@ -378,7 +379,7 @@ impl RemoteGitIndex {
             .prepare_fetch(&mut progress, Default::default())
             .map_err(|err| GitError::from(Box::new(err)))?
             .receive(&mut progress, should_interrupt)
-            .map_err(GitError::from)?;
+            .map_err(|err| GitError::from(Box::new(err)))?;
 
         crate::utils::git::write_fetch_head(&repo, &outcome, &remote)?;
         self.head_commit = Self::set_head(&mut self.index, &repo)?;
@@ -394,13 +395,13 @@ pub enum GitError {
     #[error(transparent)]
     ClonePrep(#[from] Box<gix::clone::Error>),
     #[error(transparent)]
-    CloneFetch(#[from] gix::clone::fetch::Error),
+    CloneFetch(#[from] Box<gix::clone::fetch::Error>),
     #[error(transparent)]
     Connect(#[from] Box<gix::remote::connect::Error>),
     #[error(transparent)]
     FetchPrep(#[from] Box<gix::remote::fetch::prepare::Error>),
     #[error(transparent)]
-    Fetch(#[from] gix::remote::fetch::Error),
+    Fetch(#[from] Box<gix::remote::fetch::Error>),
     #[error(transparent)]
     Open(#[from] Box<gix::open::Error>),
     #[error(transparent)]
@@ -440,54 +441,71 @@ impl GitError {
     pub fn is_spurious(&self) -> bool {
         use gix::protocol::transport::IsSpuriousError;
 
-        if let Self::Fetch(fe) | Self::CloneFetch(gix::clone::fetch::Error::Fetch(fe)) = self {
-            fe.is_spurious()
-        } else {
-            false
+        match self {
+            Self::Fetch(fe) => return fe.is_spurious(),
+            Self::CloneFetch(cf) => {
+                if let gix::clone::fetch::Error::Fetch(fe) = &**cf {
+                    return fe.is_spurious();
+                }
+            }
+            _ => {}
         }
+
+        false
     }
 
     /// Returns true if a fetch could not be completed successfully due to the
     /// repo being locked, and could succeed if retried
     #[inline]
     pub fn is_locked(&self) -> bool {
-        match self {
-            Self::Fetch(gix::remote::fetch::Error::UpdateRefs(ure))
-            | Self::CloneFetch(gix::clone::fetch::Error::Fetch(
-                gix::remote::fetch::Error::UpdateRefs(ure),
-            )) => {
-                if let gix::remote::fetch::refs::update::Error::EditReferences(ere) = ure {
-                    match ere {
-                        gix::reference::edit::Error::FileTransactionPrepare(ftpe) => {
-                            use gix::refs::file::transaction::prepare::Error as PrepError;
-                            if let PrepError::LockAcquire { source, .. }
-                            | PrepError::PackedTransactionAcquire(source) = ftpe
-                            {
-                                // currently this is either io or permanentlylocked, but just in case
-                                // more variants are added, we just assume it's possible to retry
-                                // in anything but the permanentlylocked variant
-                                !matches!(
-                                    source,
-                                    gix::lock::acquire::Error::PermanentlyLocked { .. }
-                                )
-                            } else {
-                                false
-                            }
-                        }
-                        gix::reference::edit::Error::FileTransactionCommit(ftce) => {
-                            matches!(
-                                ftce,
-                                gix::refs::file::transaction::commit::Error::LockCommit { .. }
-                            )
-                        }
-                        _ => false,
-                    }
+        let ure = match self {
+            Self::Fetch(fe) => {
+                if let gix::remote::fetch::Error::UpdateRefs(ure) = &**fe {
+                    ure
                 } else {
-                    false
+                    return false;
                 }
             }
-            Self::Lock(le) => !matches!(le, gix::lock::acquire::Error::PermanentlyLocked { .. }),
-            _ => false,
+            Self::CloneFetch(cf) => {
+                if let gix::clone::fetch::Error::Fetch(gix::remote::fetch::Error::UpdateRefs(ure)) =
+                    &**cf
+                {
+                    ure
+                } else {
+                    return false;
+                }
+            }
+            Self::Lock(le) => {
+                return !matches!(le, gix::lock::acquire::Error::PermanentlyLocked { .. })
+            }
+            _ => return false,
+        };
+
+        if let gix::remote::fetch::refs::update::Error::EditReferences(ere) = ure {
+            match ere {
+                gix::reference::edit::Error::FileTransactionPrepare(ftpe) => {
+                    use gix::refs::file::transaction::prepare::Error as PrepError;
+                    if let PrepError::LockAcquire { source, .. }
+                    | PrepError::PackedTransactionAcquire(source) = ftpe
+                    {
+                        // currently this is either io or permanentlylocked, but just in case
+                        // more variants are added, we just assume it's possible to retry
+                        // in anything but the permanentlylocked variant
+                        !matches!(source, gix::lock::acquire::Error::PermanentlyLocked { .. })
+                    } else {
+                        false
+                    }
+                }
+                gix::reference::edit::Error::FileTransactionCommit(ftce) => {
+                    matches!(
+                        ftce,
+                        gix::refs::file::transaction::commit::Error::LockCommit { .. }
+                    )
+                }
+                _ => false,
+            }
+        } else {
+            false
         }
     }
 }


### PR DESCRIPTION
Please note that I have removed the `max-performance-safe` feature
which pushes the choice to the consumer of (any) library that uses
`gix`. It's also causing less C to be compiled by default.

### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

An upgrade to the latest `gix`, which includes less dependencies now and compiles a little faster
because of it. It also avoids making decisions about performance (and the inclusion of C-crates)
by removing the `max-performance-safe` feature.

The motivation for this update is to get a new `tame-index` release for consumption in [this PR](https://github.com/obi1kenobi/cargo-semver-checks/pull/531)
so that it can also use the latest `gix` version without duplication.

### Related Issues

None
