### PR TITLE
Ignore tests that depend on endianess

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -272,6 +272,7 @@ mod test {
     use crate::PathBuf;
 
     #[test]
+    #[cfg(target_endian = "little")]
     fn canonicalizes_git_urls() {
         let super::UrlDir { dir_name, canonical } = url_to_local_dir("git+https://github.com/EmbarkStudios/cpal.git?rev=d59b4de#d59b4decf72a96932a1482cc27fe4c0b50c40d32").unwrap();
 
@@ -321,6 +322,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(target_endian = "little")]
     fn matches_cargo() {
         assert_eq!(
             get_index_details(crate::CRATES_IO_INDEX, Some(PathBuf::new())).unwrap(),

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -131,7 +131,7 @@ impl TreeUpdateBuilder {
                     i,
                     Entry {
                         mode: entry.mode,
-                        oid: entry.oid.clone().into(),
+                        oid: entry.oid.into(),
                         filename: entry.filename.to_owned(),
                     },
                 );


### PR DESCRIPTION
Just as [cargo does](https://github.com/rust-lang/cargo/blob/0871c0e2f4b6d4f95b7408fb8cef8ad3c9c8d834/src/cargo/core/source_id.rs#L930-L936), ignore the 2 tests that depend on the target being little endian.

Resolves: #36 