### PR TITLE
Fix cloning in presence of missing dir

### DIFF
--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -96,7 +96,7 @@ impl RemoteGitIndex {
                         GitError::ClonePrep(Box::new(gix::clone::Error::Init(
                             gix::init::Error::Init(gix::create::Error::CreateDirectory {
                                 source,
-                                path: index.cache.path.to_owned().into(),
+                                path: index.cache.path.clone().into(),
                             }),
                         )))
                     })?;

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -12,7 +12,7 @@ fn remote_index(
     RemoteGitIndex::new(
         GitIndex::new(IndexLocation {
             url: IndexUrl::NonCratesIo(url.as_ref().as_str().into()),
-            root: IndexPath::Exact(path.as_ref().to_owned()),
+            root: IndexPath::Exact(path.as_ref().join("sub/dir")),
         })
         .unwrap(),
         &utils::unlocked(),


### PR DESCRIPTION
This wasn't caught in tests since they always just used the root of the temp directory, and in most cases users will already have the index directories created for them by cargo, but of course that is changing as sparse has been the default for months now.

Resolves: #38 