### PR TITLE
Force disable GPG commit signing in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ twox-hash = { version = "1.6", default-features = false }
 
 [dependencies.gix]
 optional = true
-version = "0.54"
+version = "0.55"
 default-features = false
 features = ["blocking-http-transport-reqwest"]
 

--- a/deny.toml
+++ b/deny.toml
@@ -51,7 +51,7 @@ skip = [
     # toml-edit is user a newer version :p
     { name = "indexmap", version = "=1.9.3" },
     # trust-dns-resolver pulls in a new version than the rest of them use (including itself)
-    { name = "socket2", version = "=0.4.9" },
+    { name = "socket2", version = "=0.4.10" },
     # A bunch of users still of syn 1.0 :p
     { name = "syn", version = "=1.0.109" },
 ]

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -205,6 +205,11 @@ impl FakeRemote {
             .set_raw_value("committer", None, "email", "tests@integration.se")
             .unwrap();
 
+        // Disable GPG signing, it breaks testing if the user has it enabled
+        config
+            .set_raw_value("commit", None, "gpgsign", "false")
+            .unwrap();
+
         config.commit_auto_rollback().unwrap()
     }
 


### PR DESCRIPTION
By default gix will honor the user's settings (repo, global etc) but this breaks testing if the user has GPG signing enabled, which causes the commit ids to be different from what's expected.

Resolves: #29 