### PR TITLE
Update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,6 @@ features = ["blocking", "gzip"]
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-[target.'cfg(windows)'.dependencies]
-windows-targets = "0.48.5"
-
 [dev-dependencies]
 cargo_metadata = "0.18"
 rayon = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ twox-hash = { version = "1.6", default-features = false }
 
 [dependencies.gix]
 optional = true
-version = "0.55"
+version = "0.56"
 default-features = false
 features = ["blocking-http-transport-reqwest"]
 

--- a/deny.toml
+++ b/deny.toml
@@ -46,16 +46,17 @@ deny = [{ name = "openssl" }, { name = "curl" }]
 skip = [
     # several users of this old version
     { name = "bitflags", version = "=1.3.2" },
-    # imara-diff uses an old version
-    { name = "hashbrown", version = "=0.12.3" },
-    # toml-edit is user a newer version :p
-    { name = "indexmap", version = "=1.9.3" },
+    # gix dependes on 2 versions, but will (hopefully) be fixed next relesae
+    { name = "faster-hex", version = "=0.8.1" },
     # trust-dns-resolver pulls in a new version than the rest of them use (including itself)
     { name = "socket2", version = "=0.4.10" },
     # A bunch of users still of syn 1.0 :p
     { name = "syn", version = "=1.0.109" },
 ]
-skip-tree = []
+skip-tree = [
+    # sigh
+    { name = "windows-sys", version = "=0.48.0" },
+]
 
 [sources]
 unknown-registry = "deny"

--- a/src/index/git_remote.rs
+++ b/src/index/git_remote.rs
@@ -412,7 +412,7 @@ pub enum GitError {
     #[error(transparent)]
     ReferenceLookup(#[from] Box<gix::reference::find::existing::Error>),
     #[error(transparent)]
-    BlobLookup(#[from] Box<gix::odb::find::existing::Error>),
+    BlobLookup(#[from] Box<gix::object::find::existing::Error>),
     #[error(transparent)]
     RemoteLookup(#[from] Box<gix::remote::find::existing::Error>),
     #[error(transparent)]

--- a/src/utils/flock.rs
+++ b/src/utils/flock.rs
@@ -82,7 +82,7 @@ impl<'pb> LockOptions<'pb> {
 
         Ok(Self {
             path: path.into(),
-            exclusive: false,
+            exclusive: true,
             shared_fallback: false,
         })
     }

--- a/src/utils/flock/win_bindings.rs
+++ b/src/utils/flock/win_bindings.rs
@@ -5,28 +5,37 @@
     non_camel_case_types,
     clippy::upper_case_acronyms
 )]
-::windows_targets::link!(
-    "kernel32.dll" "system" "CloseHandle" fn close_handle(object : Handle) -> Bool
-);
-::windows_targets::link!(
-    "kernel32.dll" "system" "CreateEventA" fn create_event_a(event_attributes : * const
-    SecurityAttributes, manual_reset : Bool, initial_state : Bool, name : Pcstr) ->
-    Handle
-);
-::windows_targets::link!(
-    "kernel32.dll" "system" "LockFileEx" fn lock_file_ex(file : Handle, flags :
-    LockFileFlags::Enum, reserved : u32, number_of_bytes_to_lock_low : u32,
-    number_of_bytes_to_lock_high : u32, overlapped : * mut Overlapped) -> Bool
-);
-::windows_targets::link!(
-    "kernel32.dll" "system" "UnlockFile" fn unlock_file(file : Handle, file_offset_low :
-    u32, file_offset_high : u32, number_of_bytes_to_unlock_low : u32,
-    number_of_bytes_to_unlock_high : u32) -> Bool
-);
-::windows_targets::link!(
-    "kernel32.dll" "system" "WaitForSingleObject" fn wait_for_single_object(handle :
-    Handle, milliseconds : u32) -> Win32Error::Enum
-);
+#[link(name = "kernel32")]
+extern "system" {
+    #[link_name = "CloseHandle"]
+    pub fn close_handle(object: Handle) -> Bool;
+    #[link_name = "CreateEventA"]
+    pub fn create_event_a(
+        event_attributes: *const ::core::ffi::c_void,
+        manual_reset: Bool,
+        initial_state: Bool,
+        name: Pcstr,
+    ) -> Handle;
+    #[link_name = "LockFileEx"]
+    pub fn lock_file_ex(
+        file: Handle,
+        flags: LockFileFlags::Enum,
+        reserved: u32,
+        number_of_bytes_to_lock_low: u32,
+        number_of_bytes_to_lock_high: u32,
+        overlapped: *mut Overlapped,
+    ) -> Bool;
+    #[link_name = "UnlockFile"]
+    pub fn unlock_file(
+        file: Handle,
+        file_offset_low: u32,
+        file_offset_high: u32,
+        number_of_bytes_to_unlock_low: u32,
+        number_of_bytes_to_unlock_high: u32,
+    ) -> Bool;
+    #[link_name = "WaitForSingleObject"]
+    pub fn wait_for_single_object(handle: Handle, milliseconds: u32) -> Win32Error::Enum;
+}
 pub const Infinite: u32 = 4294967295;
 pub type Bool = i32;
 pub mod FileFlagsAndAttributes {
@@ -57,12 +66,6 @@ pub struct Overlapped_0_0 {
     pub offset_high: u32,
 }
 pub type Pcstr = *const u8;
-#[repr(C)]
-pub struct SecurityAttributes {
-    pub length: u32,
-    pub security_descriptor: *mut ::core::ffi::c_void,
-    pub inherit_handle: Bool,
-}
 pub mod Win32Error {
     pub type Enum = u32;
     pub const WaitObject0: Enum = 0;

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -80,7 +80,7 @@ impl TreeUpdateBuilder {
         repo: &gix::Repository,
     ) -> gix::ObjectId {
         use gix::objs::{
-            tree::{Entry, EntryMode},
+            tree::{Entry, EntryKind},
             Tree,
         };
 
@@ -94,7 +94,7 @@ impl TreeUpdateBuilder {
             match entry {
                 UpdateEntry::Blob(oid) => {
                     nt.entries.push(Entry {
-                        mode: EntryMode::Blob,
+                        mode: EntryKind::Blob.into(),
                         oid,
                         filename,
                     });
@@ -102,7 +102,7 @@ impl TreeUpdateBuilder {
                 UpdateEntry::Tree(ut) => {
                     // Check if there is already an existing tree
                     let current_tree = tree_ref.entries.iter().find_map(|tre| {
-                        if tre.filename == name && tre.mode == EntryMode::Tree {
+                        if tre.filename == name && tre.mode.is_tree() {
                             Some(repo.find_object(tre.oid).unwrap().into_tree())
                         } else {
                             None
@@ -112,7 +112,7 @@ impl TreeUpdateBuilder {
 
                     let oid = Self::create_inner(ut, &current_tree, repo);
                     nt.entries.push(Entry {
-                        mode: EntryMode::Tree,
+                        mode: EntryKind::Tree.into(),
                         oid,
                         filename,
                     });


### PR DESCRIPTION
- Fix bug in `LockOptions::cargo_package_lock`, the lock should always be exclusive, not shared
- Update gix to 0.56
- Remove `windows-targets` dependency, it will only cause version duplicates, and our usage is minimal