### PR TITLE
Fix broken links in the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ### Checklist
 
-* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
-* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
+* [ ] I have read the [Contributor Guide](../blob/main/CONTRIBUTING.md)
+* [ ] I have read and agree to the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
 * [ ] I have added a description of my changes and why I'd like them included in the section below
 
 ### Description of Changes


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

These paths seem to be relative to the PR url, not the source source file per [markdown docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links), so these were going to the organization rather than the repo.

This feels like a github issue, since having the links be relative to the published url isn't very template-like, but in the mean time this makes the links clickable.

### Related Issues

List related issues here
