### PR TITLE
Align with cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#69](https://github.com/EmbarkStudios/tame-index/pull/69) resolved an issue where 32-bit targets would have a different ident hash from what cargo would have due to cargo being target dependent in the hash calculation.
+
 ## [0.13.0] - 2024-07-25
 ### Changed
 - [PR#67](https://github.com/EmbarkStudios/tame-index/pull/67) updated `gix` -> 0.64.

--- a/tests/cache.rs
+++ b/tests/cache.rs
@@ -1,3 +1,11 @@
+#![cfg(target_pointer_width = "64")]
+
+//! Note we only run these tests if _built_ for 64-bit, as the only test targets
+//! this project cares about are 64 bit, and the issue is that, to match cargo
+//! we need to calculate the hash of the index the same, the rub is that when
+//! running a 32-bit target (eg. i686) on a 64-bit host where the cargo on the
+//! host is built for the 64-bit target as well, the local directories won't match
+
 mod utils;
 
 use tame_index::{index::cache::ValidCacheEntry, utils::get_index_details, IndexCache};


### PR DESCRIPTION
As noted in the comment, this changes the url kind from `u64` -> `usize` to match cargo, which unfortunately uses the default `derive(Hash)` which for enums uses `::core::intrinsics::discriminant_value` which for non-repr enums is...pointer size. This means the hash computed is different between 32 and 64-bit targets when they could easily be the same. :(

Resolves: https://github.com/EmbarkStudios/cargo-deny/issues/540#issuecomment-2262990465