### PR TITLE
Fix ident for non-crates.io urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#83](https://github.com/EmbarkStudios/tame-index/pull/83) adds an additional fix for non-crates.io urls not fixed in [PR#82](https://github.com/EmbarkStudios/tame-index/pull/82) as cargo now canonicalizes all URLs.
+
 ## [0.18.0] - 2025-02-20
 ### Changed
 - [PR#82](https://github.com/EmbarkStudios/tame-index/pull/82) resolved [#81](https://github.com/EmbarkStudios/tame-index/issues/81), updating the hash calculation to match cargo 1.85.0. The decision of the hash calculation is based on the cargo version, which can be specified by the user via `IndexLocation::cargo_version`, defaulting to retrieving the version from the current environment if not specified allowing the calculation to work regardless of which cargo version is used.


### PR DESCRIPTION
Cargo 1.85.0 made more changes to how urls were hashed, notably, all urls are canonicalized unlike <1.85.0

This also removes support for git+ urls as that is not needed for this crate
