### PR TITLE
Complete IndexConfig according to current Cargo reference

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -36,6 +36,7 @@ pub use crate::utils::flock::FileLock;
 pub struct IndexConfig {
     /// Pattern for creating download URLs. See [`Self::download_url`].
     pub dl: String,
+    #[serde(default)]
     /// Base URL for publishing, etc.
     pub api: Option<String>,
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -33,12 +33,15 @@ pub use crate::utils::flock::FileLock;
 
 /// Global configuration of an index, reflecting the [contents of config.json](https://doc.rust-lang.org/cargo/reference/registries.html#index-format).
 #[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct IndexConfig {
     /// Pattern for creating download URLs. See [`Self::download_url`].
     pub dl: String,
     #[serde(default)]
     /// Base URL for publishing, etc.
     pub api: Option<String>,
+    #[serde(default)]
+    auth_required: bool,
 }
 
 impl IndexConfig {
@@ -190,6 +193,7 @@ mod test {
         let crates_io = IndexConfig {
             dl: "https://crates.io/api/v1/crates".into(),
             api: Some("https://crates.io".into()),
+            auth_required: false,
         };
 
         assert_eq!(
@@ -216,6 +220,7 @@ mod test {
         let ic = IndexConfig {
             dl: "https://dl.cloudsmith.io/public/embark/deny/cargo/{crate}-{version}.crate".into(),
             api: Some("https://cargo.cloudsmith.io/embark/deny".into()),
+            auth_required: false,
         };
 
         assert_eq!(
@@ -243,6 +248,7 @@ mod test {
         let ic = IndexConfig {
             dl: "https://complex.io/ohhi/embark/rust/cargo/{lowerprefix}/{crate}/{crate}/{prefix}-{version}".into(),
             api: None,
+            auth_required: false,
         };
 
         assert_eq!(


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR makes a couple of changes to `index::IndexConfig`:

- its `API` field is now optional when deserializing from JSON, as specified by the Cargo reference;
- it now has an `auth_required` field, to reflect the `auth-required` JSON jey specific by the Cargo reference.

Note that the second bullet point is a breaking change, as the struct is fully public.
