### PR TITLE
add allowance for missing documentation to tests/cache.rs

### DIFF
--- a/tests/cache.rs
+++ b/tests/cache.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(target_pointer_width = "64")]
 
 //! Note we only run these tests if _built_ for 64-bit, as the only test targets


### PR DESCRIPTION
as the file is empty on 32-bit architectures

### Checklist

* [ x ] I have read the [Contributor Guide](../blob/main/CONTRIBUTING.md)
* [ x ] I have read and agree to the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
* [ x ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Without this patch I get: 
<img width="1510" height="574" alt="image" src="https://github.com/user-attachments/assets/f5b8260f-ce4f-499e-9e8c-fdb67c9080a7" />
on an i386 machine.

### Related Issues

n/a